### PR TITLE
PI-41 Add user self-registration in custom IDP demo UI app

### DIFF
--- a/identity-pool-reference-ui-services-nodejs/src/index.js
+++ b/identity-pool-reference-ui-services-nodejs/src/index.js
@@ -6,6 +6,7 @@ const R = require('ramda');
 require('dotenv').config();
 const ServerAuth = require('./services/utils/ServerAuth');
 const authenticationRoute = require('./routes/Authentication');
+const registerRoute = require('./routes/Register');
 const schemaRoute = require('./routes/Schema');
 const profileRoute = require('./routes/Profile');
 const passwordRoute = require('./routes/Password');
@@ -33,6 +34,7 @@ const checkServerAuth = setInterval(() => {
 }, 60000);
 
 app.use(apiPrefix + '/authenticate', authenticationRoute);
+app.use(apiPrefix + '/register', registerRoute);
 app.use(apiPrefix + '/userschema', schemaRoute);
 app.use(apiPrefix + '/self/profile', profileRoute);
 app.use(apiPrefix + '/self/password', passwordRoute);

--- a/identity-pool-reference-ui-services-nodejs/src/routes/Register.js
+++ b/identity-pool-reference-ui-services-nodejs/src/routes/Register.js
@@ -7,8 +7,6 @@ const RegisterService = require('../services/RegisterService');
 const ErrorService = require('../services/utils/ErrorService');
 
 router.post('/', (req, res) => {
-  console.log('req.body')
-  console.log(req.body);
   RegisterService.registerUser(ServerAuth.getServerSystemAccessToken(), req.body)
     .then(registerUserRes => {
       res.status(201);

--- a/identity-pool-reference-ui-services-nodejs/src/routes/Register.js
+++ b/identity-pool-reference-ui-services-nodejs/src/routes/Register.js
@@ -1,0 +1,22 @@
+'use strict';
+
+const express = require('express');
+const router = express.Router();
+const ServerAuth = require('../services/utils/ServerAuth');
+const RegisterService = require('../services/RegisterService');
+const ErrorService = require('../services/utils/ErrorService');
+
+router.post('/', (req, res) => {
+  console.log('req.body')
+  console.log(req.body);
+  RegisterService.registerUser(ServerAuth.getServerSystemAccessToken(), req.body)
+    .then(registerUserRes => {
+      res.status(201);
+      res.send(JSON.stringify({}));
+    })
+    .catch(err => {
+      ErrorService.sendErrorResponse(err, res);
+    });
+});
+
+module.exports = router;

--- a/identity-pool-reference-ui-services-nodejs/src/services/RegisterService.js
+++ b/identity-pool-reference-ui-services-nodejs/src/services/RegisterService.js
@@ -1,0 +1,17 @@
+'use strict';
+
+const AcpApiService = require('./api/AcpApiService');
+const ErrorService = require('./utils/ErrorService');
+
+class RegisterService {
+
+  registerUser (serverToken, data) {
+    return AcpApiService.createUser(serverToken, data)
+      .then(registerUserRes => {
+        return Promise.resolve(registerUserRes?.data);
+      })
+      .catch(err => ErrorService.handleAcpApiError(err));
+  }
+}
+
+module.exports = new RegisterService();

--- a/identity-pool-reference-ui-services-nodejs/src/services/api/AcpApiService.js
+++ b/identity-pool-reference-ui-services-nodejs/src/services/api/AcpApiService.js
@@ -76,8 +76,6 @@ class AcpApiService {
       url: `${acpBaseUrl}${acpIpSystemApiPrefix}/pools/${ipId}/users`,
     };
 
-    console.log(options);
-
     return axios(options);
   }
 
@@ -116,6 +114,20 @@ class AcpApiService {
       },
       data: data,
       url: `${acpBaseUrl}${acpIpSystemApiPrefix}/pools/${ipId}/users/${userId}/change_password`,
+    };
+
+    return axios(options);
+  }
+
+  sendActivationMessage (serverToken, userId, data) {
+    const options = {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${serverToken}`
+      },
+      data: data,
+      url: `${acpBaseUrl}${acpIpSystemApiPrefix}/pools/${ipId}/users/${userId}/activation/send`,
     };
 
     return axios(options);

--- a/identity-pool-reference-ui-services-nodejs/src/services/api/AcpApiService.js
+++ b/identity-pool-reference-ui-services-nodejs/src/services/api/AcpApiService.js
@@ -65,6 +65,22 @@ class AcpApiService {
     return axios(options);
   }
 
+  createUser (serverToken, data) {
+    const options = {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${serverToken}`
+      },
+      data: data,
+      url: `${acpBaseUrl}${acpIpSystemApiPrefix}/pools/${ipId}/users`,
+    };
+
+    console.log(options);
+
+    return axios(options);
+  }
+
   getUser (serverToken, userId) {
     const options = {
       method: 'GET',

--- a/identity-pool-reference-ui-services-nodejs/src/services/utils/ServerAuth.js
+++ b/identity-pool-reference-ui-services-nodejs/src/services/utils/ServerAuth.js
@@ -84,7 +84,7 @@ class ServerAuth {
       }
     }
     if (currentSystemAccessToken) {
-      const decodedSystemToken = jwt_decode(currentAdminAccessToken);
+      const decodedSystemToken = jwt_decode(currentSystemAccessToken);
       if (decodedSystemToken.exp && expiresWithinSeconds(decodedSystemToken.exp, 180)) {
         this.setServerSystemAccessToken();
       }

--- a/identity-pool-user-reference-ui-react/README.md
+++ b/identity-pool-user-reference-ui-react/README.md
@@ -90,15 +90,15 @@ const authConfig = {
 
 #### Custom Identity provider using Identity pool APIs as Authn provider
 
-As mentioned before we will use Backend for frontent(BFF) design pattern to talk to Identity Pool APIs. The Node.js backend app `identity-pool-reference-ui-services-nodejs` will act as an intermediary between the Reactjs app and Identity Pool API.
+As mentioned before we will use Backend for frontend (BFF) design pattern to talk to Identity Pool APIs. The Node.js backend app `identity-pool-reference-ui-services-nodejs` will act as an intermediary between the React.js app and Identity Pool API.
 
 Some of the Identity Pool APIs needs a trusted backend to initiate a secure communication channel and retrieve user information on behalf of the authenticated user. Later in the article, we will see couple of configurations to enable this.
 
 Let's take a sequence of activities that are relevant to this entire call flow
-* User clicks "Login" on the user auth React app, which initiates an OAuth authorize flow in Cloudentity and is redirected to the "Custom IDP login page" 
+* User clicks "Login" on the user auth React app, which initiates an OAuth authorize flow in Cloudentity and is redirected to the "Custom IDP login page"
 * User enters their identifier and password
 * Backend application calls the Identity Pool [Verify Password](https://developer.cloudentity.com/api/identity/#tag/Users/operation/verifyPassword) API
-    * If verification is successful, it calls the ACP System [Accept Login](https://docs.authorization.cloudentity.com/api/system/#tag/logins/operation/acceptLoginRequest) API, passing the user's UUID (which was returned in the Verify Password response) 
+    * If verification is successful, it calls the ACP System [Accept Login](https://docs.authorization.cloudentity.com/api/system/#tag/logins/operation/acceptLoginRequest) API, passing the user's UUID (which was returned in the Verify Password response)
 * Accept Login response contains a redirect URL to Cloudentity as a callback and the application must redirect to this URL
 * Cloudentity returns and OAuth authorization code and the authentication application can now exchange it for  idToken & accessToken
 * Now the react authentication application can store the access & idTokens to represent an authenticated user
@@ -106,7 +106,7 @@ Let's take a sequence of activities that are relevant to this entire call flow
 #### Cloudentity Identity pool identity provider as Authn provider
 
 Let's take a sequence of activities that are relevant to this entire call flow
-* User clicks "Login" on the user auth React app, which initiates an OAuth authorize flow in Cloudentity and is redirected to the "Cloudentity identity pool" identity provide authentication page 
+* User clicks "Login" on the user auth React app, which initiates an OAuth authorize flow in Cloudentity and is redirected to the "Cloudentity identity pool" identity provide authentication page
 * User enters their identifier and password
 * Cloudentity returns  OAuth authorization code and the authentication application can now exchange it for  idToken & accessToken
 * Now the react authentication application can store the access & idTokens to represent an authenticated user
@@ -117,7 +117,7 @@ Irrespective of the mechanism through which user authentication, user can now ma
 
 Above flow authenticated the user, and to allow the user to update their profile or change password etc, they need to present the accessToken to the backend app which internally proxies the calls to Cloudentity backends
 for the user represented within the accessToken using following APIs
-* [Get User details](https://developer.cloudentity.com/api/identity/#tag/Users/operation/getUser) API 
+* [Get User details](https://developer.cloudentity.com/api/identity/#tag/Users/operation/getUser) API
 * [Update User details](https://docs.authorization.cloudentity.com/api/identity/#tag/Users/operation/updateUser) API
 * [Change Password](https://docs.authorization.cloudentity.com/api/identity/#tag/Users/operation/changePassword) API
 
@@ -125,7 +125,15 @@ For the backend Nodejs application to call Cloudentity APIs, it needs to be a tr
 identity itself by obtaining an access Token. We will use OAuth client credentials flow to obtains these tokens
 for this backed to call aboe APIs. The backend app will keep track of token expiry and refresh as required.
 
-Eventhough this tutorial uses a frontend and backend pattern, this could also be used for fully server side rendedered applications.
+Even though this tutorial uses a frontend and backend pattern, this could also be used for fully server side rendered applications.
+
+#### Custom user self-registration page
+
+This demo app additionally features an example of how to set up a user registration page that uses the same BFF design to call the Identity Pool system Create User API, and subsequently the Send Activation Message API, when the new user fills out a registration form and submits it.
+
+This approach allows complete control of styling and form inputs on your custom registration page, as long as the form data is mapped into a payload that the Identity Pool API is able to process, and your user schema is configured to support any custom fields. (See the docs on the system [Create User](https://cloudentity.com/developers/api/identity_apis/identity-system-api/#tag/Users/operation/systemCreateUser) API, the [Send Activation Message](https://cloudentity.com/developers/api/identity_apis/identity-system-api/#tag/Users/operation/selfSendActivationMessage) API, and on [configuring a custom User schema](https://cloudentity.com/developers/howtos/tenant-configuration/configuring-identity-pools/)).
+
+In this scenario, be aware that configuring the option to enable self-registration in ACP does not matter, as your application is bypassing this functionality by using your own custom application and calling the underlying system API directly to create the user and send the activation message.
 
 ## Optional steps for enhanced customization use cases
 

--- a/identity-pool-user-reference-ui-react/src/App.js
+++ b/identity-pool-user-reference-ui-react/src/App.js
@@ -42,6 +42,7 @@ function App() {
                 <Routes>
                   <Route index element={<Unauthorized className="App" auth={authenticated} handleLogin={authorize} />} />
                   <Route path="login" element={<Unauthorized role="login" className="App" auth={authenticated} handleLogin={authorize} />} />
+                  <Route path="register" element={<Unauthorized role="register" className="App" auth={authenticated} handleLogin={authorize} />} />
                   <Route path="authorized" element={<Authorized auth={authenticated} handleLogout={clearAuth} />} />
                 </Routes>
               </BrowserRouter>

--- a/identity-pool-user-reference-ui-react/src/api/api.js
+++ b/identity-pool-user-reference-ui-react/src/api/api.js
@@ -10,6 +10,7 @@ export const api = {
 
   // Must be called if custom IDP/login page being used
   identifierPasswordLogin: (body) => nodeAppBase.post({url: '/authenticate/identifierpassword', body}),
+  selfRegisterUser: (body) => nodeAppBase.post({url: '/register', body}),
   fetchProfileSchema: () => nodeAppBase.get({url: '/userschema'}),
   fetchProfileCustomIdp: () => nodeAppBase.get({url: '/self/profile'}),
   updateProfileCustomIdp: (body) => nodeAppBase.put({url: '/self/profile', body}),


### PR DESCRIPTION
## Jira task - [https://cloudentity.atlassian.net/browse/PI-41](PI-41)

## Release Notes Description

Added to the user profile demo UI app: **User self registration on the custom IDP login page.**

- This self registration feature includes a new link on the custom IDP login page to a registration page. Currently there is just a simple form with the ability to set first and last name plus email. When submit is successful, the user is shown a confirmation page prompting them to check their email for an activation link (there is not yet a custom activation page, as the link in the activation email is not simple to configure - the activation page can still be customized using the Themes feature in ACP).
- The registration flow is handled via a BFF pattern whereby the demo UI sends the registration form data to the intermediate Node.js demo application, which then makes trusted requests to the ACP System API to create the user and send the activation message. The response is relayed from the Node.js demo application back to the demo UI.
- If not using a custom IDP, it is still possible to reach the registration page and successfully self-register, as long as the frontend/backend demo apps are both running and correctly configured, by going directly to http://localhost:3000/register (see README documentation for how to configure these apps).

## Screenshots:

Login page with new register link
<img width="1792" alt="Screen Shot 2023-02-16 at 9 35 28 AM" src="https://user-images.githubusercontent.com/15165856/219445244-63d95cee-f481-4774-9d6a-7bde5977c198.png">

Register page
<img width="1792" alt="Screen Shot 2023-02-16 at 9 40 36 AM" src="https://user-images.githubusercontent.com/15165856/219445365-11883e5e-8082-438e-bf6e-ec81d5d4ed95.png">

Register confirm page
<img width="1792" alt="Screen Shot 2023-02-16 at 9 36 26 AM" src="https://user-images.githubusercontent.com/15165856/219445470-5c03e0d9-2e73-460f-a5e2-b13256f9fa1c.png">

